### PR TITLE
Fixes the exportAll -> export_all outline API change

### DIFF
--- a/exe/outliner-export
+++ b/exe/outliner-export
@@ -20,11 +20,28 @@ local_directory = ARGV[0]
 CLIENT = Outliner::Client.new ENV['OUTLINE_BASE_URI']
 
 # Download the complete zip
-response = CLIENT.collections_exportAll(download: true)
+response = CLIENT.collections__export_all(format: "outline-markdown")
+
+raise 'Failed to trigger export_all action' if not response['success']
+
+file_operation_id = response['data']['fileOperation']['id']
+fop_info_response = nil
+i = 0
+loop do
+  i += 1
+  raise 'Timed out waiting for the file export operation to complete' if i > 20
+  sleep(2*i)
+  fop_info_response = CLIENT.fileOperations__info(id: file_operation_id)
+  raise 'Failed to query export file operation info' if not fop_info_response['ok']
+  break if fop_info_response['data']['state'] == 'complete'
+end
+
+fop_redirect_response = CLIENT.fileOperations__redirect(id: file_operation_id)
+
 
 # Extract it to a tempfle
 file = Tempfile.new('download.zip')
-File.open(file.path, 'w') { |f| f.write(response.body) }
+File.open(file.path, 'w') { |f| f.write(fop_redirect_response) }
 
 `unzip -o "#{file.path}" -d "#{local_directory}"`
 

--- a/exe/outliner-export
+++ b/exe/outliner-export
@@ -36,14 +36,14 @@ loop do
   break if fop_info_response['data']['state'] == 'complete'
 end
 
-fop_redirect_response = CLIENT.fileOperations__redirect(id: file_operation_id)
+begin
+  fop_redirect_response = CLIENT.fileOperations__redirect({id: file_operation_id}, {no_follow: true})
+rescue HTTParty::RedirectionTooDeep => e
+  response = HTTParty.get e.response.header['location']
+  file = Tempfile.new('download.zip')
+  File.open(file.path, 'w') { |f| f.write(response.body) }
+  `unzip -o "#{file.path}" -d "#{local_directory}"`
+  file.unlink
+end
 
 
-# Extract it to a tempfle
-file = Tempfile.new('download.zip')
-File.open(file.path, 'w') { |f| f.write(fop_redirect_response) }
-
-`unzip -o "#{file.path}" -d "#{local_directory}"`
-
-# Delete tempfile
-file.unlink

--- a/exe/outliner-import
+++ b/exe/outliner-import
@@ -28,7 +28,7 @@ def create_documents_recursively(directory, collection_id, parent_document_id = 
     }
 
     params[:parentDocumentId] = parent_document_id if parent_document_id
-    CLIENT.documents_create(params)
+    CLIENT.documents__create(params)
     puts "[-] #{file}"
   end
 
@@ -42,7 +42,7 @@ def create_documents_recursively(directory, collection_id, parent_document_id = 
       publish: true,
       parentDocumentId: parent_document_id
     }
-    response = CLIENT.documents_create(params)
+    response = CLIENT.documents__create(params)
     create_documents_recursively(dir, collection_id, response['data']['id'])
   end
   Dir.chdir cwd
@@ -65,7 +65,7 @@ begin
 rescue StandardError? => e
   # If we fail, print an error, and delete the collection
   puts "[E] Import failed with error: #{e.message}"
-  CLIENT.collections_delete(id: root_collection_id)
+  CLIENT.collections__delete(id: root_collection_id)
   puts '[E] Deleted collection, please report the issue or retry'
   exit 1
 end

--- a/lib/outliner/client.rb
+++ b/lib/outliner/client.rb
@@ -11,17 +11,18 @@ module Outliner
     end
 
     def find_or_create_collection(name)
-      collections = self.collections_list(limit: 100)['data']
+      collections = self.collections__list(limit: 100)['data']
       collections.filter!{|c|c['name'] == name}
       if collections.size >= 1
         collections[0]['id']
       else
-        self.collections_create(name: name, description: 'Imported Collection')['data']['id']
+        self.collections__create(name: name, description: 'Imported Collection')['data']['id']
       end
     end
 
     def method_missing(method_name, params = {})
-      method_name = '/' + method_name.to_s.sub('_', '.')
+      method_name = '/' + method_name.to_s.sub('__', '.')
+      puts method_name
       body = {token: @token}.merge(params).to_json
       options = {
         body: body,

--- a/lib/outliner/client.rb
+++ b/lib/outliner/client.rb
@@ -20,19 +20,19 @@ module Outliner
       end
     end
 
-    def method_missing(method_name, params = {})
-      method_name = '/' + method_name.to_s.sub('__', '.')
-      puts method_name
-      body = {token: @token}.merge(params).to_json
+    def method_missing(method_name, params = {}, options = {})
+      method_name = "/#{method_name.to_s.sub('__', '.')}"
+
       options = {
-        body: body,
+        body: params.to_json,
         headers: {
-          'Accept'=>'application/json',
-          'Content-Type': 'application/json',
-          'User-Agent': "Outliner/#{Outliner::VERSION}"
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json',
+          'User-Agent' => "Outliner/#{Outliner::VERSION}",
+          'Authorization' => "Bearer #{@token}"
         },
-        format: :json
-      }
+        format: :json,
+      }.merge!(options)
 
       self.class.post(method_name, options)
     end


### PR DESCRIPTION
Seems the outline API has changed the collections export endpoint as of ( https://github.com/outline/openapi/commit/ef782ca7ed3ff8d0b21bd2de332ba09cb20780fb#diff-543af4ad11a870531a5ccc129b39a1b4d2c7860812f2015b697524c5d636f800R1084 ) - now we have to check the created FileOperation for completion before we can download the zip file.

Necessary change introduced in this PR:
As until now the client implementation replaced single underscores with a dot this was not compatible with underscores in the API URIs. Because of that only **double** underscores in the method name should be replaced with a dot instead.