### PR TITLE
Fixes the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.3-alpine3.19
+
+RUN apk add --no-cache git openssh-client rsync && \
+    echo -e "StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
+    mkdir /root/.ssh
 
 WORKDIR /outliner
 COPY . /outliner/
 
-RUN gem install bundler && \
+RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc && \
+    apk add --no-cache alpine-sdk && \
+    gem update --system && \
+    gem install bundler && \
     bundle install && \
-    apk add --no-cache git openssh-client rsync && \
-    echo -e "StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
-    mkdir /root/.ssh
+    apk del --no-cache alpine-sdk && \
+    rm ~/.gemrc
 
 ENTRYPOINT ["/outliner/entrypoint.sh"]


### PR DESCRIPTION
The Docker build stopped working as it is based on an outdated base image. Updated the base image to ruby:3.3-alpine3.19 and installed alpine-sdk to be able to build all dependencies